### PR TITLE
feature : Kafka retry 비동기 수행 리팩토링 및 재시도 실패 -> dlt 전송 후 FailedMessage …

### DIFF
--- a/src/main/java/com/gg/gong9/global/utils/kafkaFailed/Repository/FailedMessageRepository.java
+++ b/src/main/java/com/gg/gong9/global/utils/kafkaFailed/Repository/FailedMessageRepository.java
@@ -1,0 +1,7 @@
+package com.gg.gong9.global.utils.kafkaFailed.Repository;
+
+import com.gg.gong9.global.utils.kafkaFailed.entity.FailedMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FailedMessageRepository extends JpaRepository<FailedMessage, Long> {
+}

--- a/src/main/java/com/gg/gong9/global/utils/kafkaFailed/entity/FailedMessage.java
+++ b/src/main/java/com/gg/gong9/global/utils/kafkaFailed/entity/FailedMessage.java
@@ -1,0 +1,37 @@
+package com.gg.gong9.global.utils.kafkaFailed.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "failed_messages")
+public class FailedMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String topic;          // 메시지가 온 토픽
+
+    @Column(columnDefinition = "TEXT")
+    private String payload;        // 실패 메시지 내용
+
+    private String exception;      // 발생한 예외 클래스/메시지
+
+    private LocalDateTime failedAt = LocalDateTime.now();
+
+    public FailedMessage(String topic, String payload, String exception) {
+        this.topic = topic;
+        this.payload = payload;
+        this.exception = exception;
+        this.failedAt = LocalDateTime.now();
+    }
+
+
+}

--- a/src/main/java/com/gg/gong9/global/utils/kafkaFailed/service/FailedMessageService.java
+++ b/src/main/java/com/gg/gong9/global/utils/kafkaFailed/service/FailedMessageService.java
@@ -1,0 +1,22 @@
+package com.gg.gong9.global.utils.kafkaFailed.service;
+
+import com.gg.gong9.global.utils.kafkaFailed.Repository.FailedMessageRepository;
+import com.gg.gong9.global.utils.kafkaFailed.entity.FailedMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FailedMessageService {
+
+    private final FailedMessageRepository failedMessageRepository;
+
+    public void saveFailedMessage(String payload, String topic, Exception ex) {
+        FailedMessage failedMessage = new FailedMessage(
+                topic,
+                payload,
+                ex.toString()
+        );
+        failedMessageRepository.save(failedMessage);
+    }
+}

--- a/src/main/java/com/gg/gong9/notification/sms/kafka/SmsKafkaConsumer.java
+++ b/src/main/java/com/gg/gong9/notification/sms/kafka/SmsKafkaConsumer.java
@@ -3,15 +3,26 @@ package com.gg.gong9.notification.sms.kafka;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gg.gong9.global.utils.kafkaFailed.service.FailedMessageService;
 import com.gg.gong9.notification.sms.controller.dto.SmsMessage;
 import com.gg.gong9.notification.sms.service.SmsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.DltHandler;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.retrytopic.DltStrategy;
 import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.retry.annotation.Backoff;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+import static org.springframework.kafka.retrytopic.TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE;
 
 @Service
 @RequiredArgsConstructor
@@ -20,7 +31,15 @@ public class SmsKafkaConsumer {
 
     private final ObjectMapper objectMapper;
     private final SmsService smsService;
+    private final FailedMessageService failedMessageService;
 
+    @RetryableTopic(
+            attempts = "3",
+            backoff = @Backoff(delay = 10 * 1000, multiplier = 3, maxDelay = 10 * 60 * 1000),
+            topicSuffixingStrategy = SUFFIX_WITH_INDEX_VALUE,
+            dltStrategy = DltStrategy.ALWAYS_RETRY_ON_ERROR,
+            include = { TimeoutException.class , IOException.class} //리트라이함
+    )
     @KafkaListener(topics = "sms-topic", groupId = "sms-group", concurrency = "3",containerFactory = "kafkaListenerContainerFactory")
     public void listenSmsNotifyTopic(String message, Acknowledgment ack) throws JsonProcessingException {
         try {
@@ -38,9 +57,17 @@ public class SmsKafkaConsumer {
             ack.acknowledge();
         } catch (Exception e) {
             log.error("SMS 발송 처리 실패 - 메시지: {}, 에러: {}", message, e.toString(), e);
-            throw e; // 예외 던져서 errorHandler가 처리
+            throw e;
         }
     }
+
+    @DltHandler
+    public void handleFailedMessage(String failedMessage, Exception ex, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
+        log.error("DLT 메시지 도착, 재시도 모두 실패, 수동 처리 필요: {}", failedMessage, ex);
+
+        failedMessageService.saveFailedMessage(failedMessage, topic, ex);
+    }
+
 
     private void sendSingleSms(SmsMessage sms){
         log.info("단건 SMS 발송 요청 - userId: {}, type: {}", sms.userId(), sms.type());


### PR DESCRIPTION
…db 저장

resolved: #1 <!-- 관련된 이슈 번호를 작성해주세요 -->
## 📌 작업 개요 <!-- 어떤 기능을 구현했는지 한두 줄로 요약 -->
Kafka retry 비동기 수행 리팩토링 및 재시도 실패 -> dlt 전송 후 FailedMessage 저장
## 💻 상세 작업 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- Kafka retry 비동기 수행으로 리팩토링
- 모든 재시도 실패 -> dlt 전송 후 , FailedMessage db 저장
## 🔄 피드백 반영 사항  <!-- 코드리뷰에서 받은 피드백을 반영한 내역을 정리해주세요. 재PR 시 사용 (재PR 아닌 경우 삭제) -->

## ✅ 중점 리뷰 포인트 / 궁금한 점 <!-- 리뷰어가 중점적으로 확인했으면 하는 부분, 고민되었던 지점, 질문하고 싶은 내용 등 -->
